### PR TITLE
fix: compilation signature mismatch error

### DIFF
--- a/src/Ed/Components/ProjInfo.as
+++ b/src/Ed/Components/ProjInfo.as
@@ -480,7 +480,7 @@ namespace CM_Editor {
                 _wiz_generatedJsonString = "";
             }
 
-            UI::InputTextMultiline("##json", _wiz_generatedJsonString, false, vec2(-1, 200), UI::InputTextFlags::ReadOnly);
+            UI::InputTextMultiline("##json", _wiz_generatedJsonString, vec2(-1, 200), UI::InputTextFlags::ReadOnly);
 
             UI::SeparatorText("Upload");
             UI::AlignTextToFramePadding();


### PR DESCRIPTION
Fixes this compilation error:

<img width="1680" height="179" alt="image" src="https://github.com/user-attachments/assets/e280febe-1ad8-4538-adb7-92a1817ad2f6" />

Also thanks for all your work @XertroV! You're the goat